### PR TITLE
fix: toggle controlbar icon on dynamic permission change

### DIFF
--- a/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.tsx
+++ b/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.tsx
@@ -29,6 +29,12 @@ export class DyteCameraToggle {
     }
   };
 
+  private meetingPermissionsUpdateListener = (patch?: { media?: { video?: { canProduce?: number } } }) => {
+    if (patch?.media?.video) {
+      this.canProduceVideo = this.meeting.self.permissions.canProduceVideo === 'ALLOWED';
+    }
+  }
+
   /** Variant */
   @Prop({ reflect: true }) variant: ControlBarVariant = 'button';
 
@@ -61,6 +67,7 @@ export class DyteCameraToggle {
     this.meeting?.self.removeListener('videoUpdate', this.videoUpdateListener);
     this.meeting?.self.removeListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
     this.meeting?.stage?.removeListener('stageStatusUpdate', this.stageStatusListener);
+    this.meeting?.self?.permissions?.removeListener('permissionsUpdate', this.meetingPermissionsUpdateListener);
   }
 
   @Watch('meeting')
@@ -74,6 +81,7 @@ export class DyteCameraToggle {
       self.addListener('videoUpdate', this.videoUpdateListener);
       self.addListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
       stage?.addListener('stageStatusUpdate', this.stageStatusListener);
+      meeting?.self?.permissions?.addListener('permissionsUpdate', this.meetingPermissionsUpdateListener);
     }
   }
 

--- a/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.tsx
+++ b/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.tsx
@@ -29,11 +29,13 @@ export class DyteCameraToggle {
     }
   };
 
-  private meetingPermissionsUpdateListener = (patch?: { media?: { video?: { canProduce?: number } } }) => {
+  private meetingPermissionsUpdateListener = (patch?: {
+    media?: { video?: { canProduce?: number } };
+  }) => {
     if (patch?.media?.video) {
       this.canProduceVideo = this.meeting.self.permissions.canProduceVideo === 'ALLOWED';
     }
-  }
+  };
 
   /** Variant */
   @Prop({ reflect: true }) variant: ControlBarVariant = 'button';
@@ -67,7 +69,10 @@ export class DyteCameraToggle {
     this.meeting?.self.removeListener('videoUpdate', this.videoUpdateListener);
     this.meeting?.self.removeListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
     this.meeting?.stage?.removeListener('stageStatusUpdate', this.stageStatusListener);
-    this.meeting?.self?.permissions?.removeListener('permissionsUpdate', this.meetingPermissionsUpdateListener);
+    this.meeting?.self?.permissions?.removeListener(
+      'permissionsUpdate',
+      this.meetingPermissionsUpdateListener
+    );
   }
 
   @Watch('meeting')
@@ -81,7 +86,10 @@ export class DyteCameraToggle {
       self.addListener('videoUpdate', this.videoUpdateListener);
       self.addListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
       stage?.addListener('stageStatusUpdate', this.stageStatusListener);
-      meeting?.self?.permissions?.addListener('permissionsUpdate', this.meetingPermissionsUpdateListener);
+      meeting?.self?.permissions?.addListener(
+        'permissionsUpdate',
+        this.meetingPermissionsUpdateListener
+      );
     }
   }
 

--- a/packages/core/src/components/dyte-mic-toggle/dyte-mic-toggle.tsx
+++ b/packages/core/src/components/dyte-mic-toggle/dyte-mic-toggle.tsx
@@ -29,11 +29,13 @@ export class DyteMicToggle {
     }
   };
 
-  private meetingPermissionsUpdateListener = (patch?: { media?: { audio?: { canProduce?: number } } }) => {
+  private meetingPermissionsUpdateListener = (patch?: {
+    media?: { audio?: { canProduce?: number } };
+  }) => {
     if (patch?.media?.audio) {
       this.canProduceAudio = this.meeting.self.permissions.canProduceAudio === 'ALLOWED';
     }
-  }
+  };
 
   /** Variant */
   @Prop({ reflect: true }) variant: ControlBarVariant = 'button';
@@ -67,7 +69,10 @@ export class DyteMicToggle {
     this.meeting?.self.removeListener('audioUpdate', this.audioUpdateListener);
     this.meeting?.self.removeListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
     this.meeting?.stage?.removeListener('stageStatusUpdate', this.stageStatusListener);
-    this.meeting?.self?.permissions?.removeListener('permissionsUpdate', this.meetingPermissionsUpdateListener);
+    this.meeting?.self?.permissions?.removeListener(
+      'permissionsUpdate',
+      this.meetingPermissionsUpdateListener
+    );
   }
 
   @Watch('meeting')
@@ -82,7 +87,10 @@ export class DyteMicToggle {
       self.addListener('audioUpdate', this.audioUpdateListener);
       self.addListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
       stage?.addListener('stageStatusUpdate', this.stageStatusListener);
-      meeting.self?.permissions?.addListener('permissionsUpdate', this.meetingPermissionsUpdateListener);
+      meeting.self?.permissions?.addListener(
+        'permissionsUpdate',
+        this.meetingPermissionsUpdateListener
+      );
     }
   }
 


### PR DESCRIPTION
| Linear Issue |
| :----------: |
|  fixes WEB-4012  |

### Description

When the permission for audio or video is dynamically disabled in a session, the affected participants' video and audio toggle button disappear from the controlbar. They also re-appear when the permission is dynamically provided.
