### PR TITLE
fix(off-stage-actions): mic and camera toggle should not be shown off stage

### DIFF
--- a/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.tsx
+++ b/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.tsx
@@ -5,6 +5,7 @@ import state from '../../lib/store';
 import { Meeting, Peer, MediaPermission } from '../../types/dyte-client';
 import { PermissionSettings, Size, States } from '../../types/props';
 import { ControlBarVariant } from '../dyte-controlbar-button/dyte-controlbar-button';
+import { StageStatus } from '@dytesdk/web-core';
 
 /**
  * A button which toggles your camera.
@@ -20,6 +21,7 @@ export class DyteCameraToggle {
   };
 
   private stageStatusListener = () => {
+    this.stageStatus = this.meeting.stage.status;
     this.canProduceVideo = this.meeting.self.permissions.canProduceVideo === 'ALLOWED';
   };
 
@@ -58,6 +60,8 @@ export class DyteCameraToggle {
 
   @State() cameraPermission: MediaPermission = 'NOT_REQUESTED';
 
+  @State() stageStatus: StageStatus = 'OFF_STAGE';
+
   /** Emits updated state data */
   @Event({ eventName: 'dyteStateUpdate' }) stateUpdate: EventEmitter<States>;
 
@@ -83,6 +87,7 @@ export class DyteCameraToggle {
       this.cameraPermission = self.mediaPermissions.video || 'NOT_REQUESTED';
       this.videoEnabled = self.videoEnabled;
 
+      this.stageStatus = meeting.stage.status;
       self.addListener('videoUpdate', this.videoUpdateListener);
       self.addListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
       stage?.addListener('stageStatusUpdate', this.stageStatusListener);
@@ -176,7 +181,11 @@ export class DyteCameraToggle {
   }
 
   render() {
-    if (!this.canProduceVideo || this.meeting?.meta.viewType === 'AUDIO_ROOM') {
+    if (
+      !this.canProduceVideo ||
+      this.meeting?.meta.viewType === 'AUDIO_ROOM' ||
+      ['OFF_STAGE', 'REQUESTED_TO_JOIN_STAGE'].includes(this.stageStatus)
+    ) {
       return null;
     }
 

--- a/packages/core/src/components/dyte-mic-toggle/dyte-mic-toggle.tsx
+++ b/packages/core/src/components/dyte-mic-toggle/dyte-mic-toggle.tsx
@@ -5,6 +5,7 @@ import { DyteI18n, useLanguage } from '../../lib/lang';
 import { PermissionSettings, Size, States } from '../../types/props';
 import { ControlBarVariant } from '../dyte-controlbar-button/dyte-controlbar-button';
 import storeState from '../../lib/store';
+import { StageStatus } from '@dytesdk/web-core';
 
 /**
  * A button which toggles your microphone.
@@ -20,6 +21,7 @@ export class DyteMicToggle {
   };
 
   private stageStatusListener = () => {
+    this.stageStatus = this.meeting.stage.status;
     this.canProduceAudio = this.meeting.self.permissions.canProduceAudio === 'ALLOWED';
   };
 
@@ -58,6 +60,8 @@ export class DyteMicToggle {
 
   @State() micPermission: MediaPermission = 'NOT_REQUESTED';
 
+  @State() stageStatus: StageStatus = 'OFF_STAGE';
+
   /** Emits updated state data */
   @Event({ eventName: 'dyteStateUpdate' }) stateUpdate: EventEmitter<States>;
 
@@ -84,6 +88,7 @@ export class DyteMicToggle {
       this.micPermission = meeting.self.mediaPermissions.audio || 'NOT_REQUESTED';
       this.audioEnabled = self.audioEnabled;
 
+      this.stageStatus = meeting.stage.status;
       self.addListener('audioUpdate', this.audioUpdateListener);
       self.addListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
       stage?.addListener('stageStatusUpdate', this.stageStatusListener);
@@ -177,7 +182,10 @@ export class DyteMicToggle {
   }
 
   render() {
-    if (!this.canProduceAudio) {
+    if (
+      !this.canProduceAudio ||
+      ['OFF_STAGE', 'REQUESTED_TO_JOIN_STAGE'].includes(this.stageStatus)
+    ) {
       return null;
     }
 

--- a/packages/core/src/components/dyte-screen-share-toggle/dyte-screen-share-toggle.tsx
+++ b/packages/core/src/components/dyte-screen-share-toggle/dyte-screen-share-toggle.tsx
@@ -6,6 +6,7 @@ import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@st
 import logger from '../../utils/logger';
 import { ControlBarVariant } from '../dyte-controlbar-button/dyte-controlbar-button';
 import storeState from '../../lib/store';
+import { StageStatus } from '@dytesdk/web-core';
 
 const deviceCanScreenShare = () => {
   return (
@@ -77,6 +78,8 @@ export class DyteScreenShareToggle {
     disable: false,
   };
 
+  @State() stageStatus: StageStatus = 'OFF_STAGE';
+
   /**
    * Emit api error events
    */
@@ -122,6 +125,7 @@ export class DyteScreenShareToggle {
   };
 
   private stageStatusListener = () => {
+    this.stageStatus = this.meeting.stage.status;
     this.canScreenShare = this.meeting.self.permissions.canProduceScreenshare === 'ALLOWED';
   };
 
@@ -193,6 +197,7 @@ export class DyteScreenShareToggle {
         },
       });
 
+      this.stageStatus = meeting.stage.status;
       meeting.participants.joined.addListener('screenShareUpdate', this.screenShareListener);
       meeting.participants.joined.addListener('participantLeft', this.participantLeftListener);
       self.addListener('screenShareUpdate', this.screenShareListener);
@@ -291,7 +296,11 @@ export class DyteScreenShareToggle {
   }
 
   render() {
-    if (!deviceCanScreenShare() || !this.canScreenShare) {
+    if (
+      !deviceCanScreenShare() ||
+      !this.canScreenShare ||
+      ['OFF_STAGE', 'REQUESTED_TO_JOIN_STAGE'].includes(this.stageStatus)
+    ) {
       return null;
     }
 


### PR DESCRIPTION
| Linear Issue |
| :----------: |
| fixes WEB-4021 |

### Description

Mic and camera toggle were shown off stage in cases where permissions were altered midway using dynamic permissions or  ui-kit addons.

### Steps to reproduce
As a webinar viewer, Stay off stage and run the following code snippet
```
// Set Not permissions as allowed
Object.defineProperty(
    this.meeting?.self.permissions,
    "canProduceAudio", {
        value: 'NOT_ALLOWED',
        configurable: true
    }
);
meeting?.self.permissions.emit("micPermissionUpdate");

// Now Set permissions as Allowed
Object.defineProperty(
    this.meeting?.self.permissions,
    "canProduceAudio", {
        value: 'ALLOWED',
        configurable: true
    }
);
meeting?.self.permissions.emit("micPermissionUpdate");
```

### Screenshots

<!-- Add screenshots if applicable -->
