### PR TITLE
feat(internal): added ability to show view only public chat

### DIFF
--- a/packages/core/src/utils/sidebar.ts
+++ b/packages/core/src/utils/sidebar.ts
@@ -10,6 +10,7 @@ export const canViewChat = (meeting: Meeting) => {
 
   return (
     chatPublic.canSend ||
+    (chatPublic as any).canReceive || // TODO(ravindra-dyte): add web-core equivalent of chatPublic.canReceive, remove type casting
     chatPublic.text ||
     chatPublic.files ||
     chatPrivate.canSend ||


### PR DESCRIPTION
| Linear Issue |
| :----------: |
| fixes WEB-4023 |

### Description

In case of dynamic permission change, Chat box was getting hidden due to the canViewChat check. Added canReceive similar to the chatPrivate.canReceive.

Note: Web Core equivalent is not added yet. It has to be added and the type casting has to be removed from this PR.

### Steps to test

Run the following code snippet for presets that have everything disabled for public chats.

```
        Object.defineProperty(
            meeting?.self.permissions.chatPublic,
            "canReceive",
            {
                value: true
            }
        );
```
