### PR TITLE
feat: improve macos permission messages

### DIFF
--- a/packages/core/src/lib/lang/default-language.ts
+++ b/packages/core/src/lib/lang/default-language.ts
@@ -306,6 +306,7 @@ export const defaultLanguage = {
   'cta.continue': 'Ignore',
   'cta.reload': 'Reload',
   'cta.confirmation': 'Are you sure?',
+  'cta.system_settings': 'Open Settings',
   'remote_access.empty': 'There are no remote requests, yet.',
   'remote_access.requests':
     'The following people have requested remote control to your screen share.',


### PR DESCRIPTION
- Handle multiple permission failures at the same time (ie screenshare system denied, camera denied)
- Show systems settings deep link for macOS SYSTEM_DENIED
- Do not show audio,video permission images steps for Chrome screenshare SYSTEM_DENIED