### PR TITLE
feat(livestream): show livestream viewers and stage list

### DIFF
--- a/packages/core/src/components/dyte-participants-stage-list/dyte-participants-stage-list.tsx
+++ b/packages/core/src/components/dyte-participants-stage-list/dyte-participants-stage-list.tsx
@@ -48,8 +48,6 @@ export class DyteParticipants {
 
   @State() participants: Peer[] = [];
 
-  @State() showStageList: boolean = false;
-
   connectedCallback() {
     this.meetingChanged(this.meeting);
     this.searchChanged(this.search);
@@ -145,14 +143,10 @@ export class DyteParticipants {
   }
 
   private updateStageList = () => {
-    if (this.meeting?.meta.viewType === 'LIVESTREAM') {
-      this.showStageList = this.meeting?.stage?.status === 'ON_STAGE';
-    } else this.showStageList = true;
     this.getParticipants(this.search);
   };
 
   render() {
-    if (!this.showStageList) return;
     return (
       <Host>
         <div class="participants-container">

--- a/packages/core/src/components/dyte-participants-viewer-list/dyte-participants-viewer-list.tsx
+++ b/packages/core/src/components/dyte-participants-viewer-list/dyte-participants-viewer-list.tsx
@@ -125,9 +125,7 @@ export class DyteParticipantsViewers {
 
   // TODO: (ishita1805) Remove viewtype check when we start supporting viewers in livestream.
   private shouldShowViewers = () => {
-    return (
-      this.meeting?.self?.permissions?.stageEnabled && this.meeting?.meta?.viewType !== 'LIVESTREAM'
-    );
+    return this.meeting?.self?.permissions?.stageEnabled;
   };
 
   render() {

--- a/packages/core/src/components/dyte-virtualized-list/dyte-virtualized-participant-list.tsx
+++ b/packages/core/src/components/dyte-virtualized-list/dyte-virtualized-participant-list.tsx
@@ -39,14 +39,14 @@ export class DyteVirtualizedParticipantList {
 
   componentDidLoad() {
     this.recalculatePositioning();
+    // Set up the scroll event listener
+    this.el.querySelector('.virtual-list-container').addEventListener('scroll', this.onScroll);
+    window.addEventListener('resize', this.recalculatePositioning);
   }
 
   private recalculatePositioning = () => {
     // Measure container height and update visible items
     this.updateContainerHeight();
-    // Set up the scroll event listener
-    this.el.querySelector('.virtual-list-container').addEventListener('scroll', this.onScroll);
-    window.addEventListener('resize', this.updateContainerHeight);
 
     // Check for the first item height
     requestAnimationFrame(() => {
@@ -62,7 +62,7 @@ export class DyteVirtualizedParticipantList {
   disconnectedCallback() {
     // Remove event listeners to prevent memory leaks
     this.el.querySelector('.virtual-list-container').removeEventListener('scroll', this.onScroll);
-    window.removeEventListener('resize', this.updateContainerHeight);
+    window.removeEventListener('resize', this.recalculatePositioning);
   }
 
   private updateContainerHeight = () => {

--- a/packages/core/src/utils/sidebar.ts
+++ b/packages/core/src/utils/sidebar.ts
@@ -1,5 +1,5 @@
 import { Meeting } from '../types/dyte-client';
-import { isLiveStreamViewer, showLivestream } from './livestream';
+import { isLiveStreamViewer } from './livestream';
 
 export const canViewChat = (meeting: Meeting) => {
   if (meeting && !meeting.chat) return false;
@@ -33,11 +33,7 @@ export const canViewParticipants = (meeting: Meeting) => {
   if (!meeting.self.permissions?.showParticipantList) {
     return false;
   }
-  if (showLivestream(meeting) && !meeting.self.permissions?.acceptStageRequests) return false;
   if (meeting && !meeting.participants) return false;
-  if (meeting.meta.viewType === 'LIVESTREAM') {
-    return meeting.self.permissions.acceptStageRequests || meeting?.stage?.status === 'ON_STAGE';
-  }
   const config = meeting?.self.config;
   if (config && !config.controlBar.elements.participants) return false;
   return true;


### PR DESCRIPTION
| Linear Issue |
| :----------: |
| fixes WEB-4074 |

### Description

1. Showing viewers list and Stage list to all viewers. Earlier livestreams didn't used to have viewer tab and viewers didn't have the option to see other viewers or hosts.

2. Made some performance fixes. 

3. Changed Stage tab label to Participants

### Screenshots

<!-- Add screenshots if applicable -->
