### PR TITLE
fix(dyte-chat): fixed code indentation for chat messages

### DIFF
--- a/packages/core/src/components/dyte-markdown-view/dyte-markdown-view.tsx
+++ b/packages/core/src/components/dyte-markdown-view/dyte-markdown-view.tsx
@@ -95,7 +95,7 @@ export class DyteMarkdownView {
     });
 
     if (isCodeBlock) {
-      return <pre>{message}</pre>;
+      return <pre style={{ whiteSpace: 'pre', overflow: 'scroll' }}>{lines.join('\n')}</pre>;
     }
 
     return message;


### PR DESCRIPTION
| Linear Issue |
| :----------: |
| fixes WEB-4104 |

### Description

Fixed indentation issues with chat messages. Each message with a code block, now can have its own individual scroll for the content.

Only requisite is that the code should be pre-formatted. There will be no language specific formatting performed on messages.

### Video Demo

https://github.com/user-attachments/assets/e507beea-c39f-481a-b0d9-84b6bacfa49c




