### PR TITLE
fix(ui-kit-addons): hand raise addon if not place at the end of the addon list, failed to add hand raise button

### DIFF
--- a/packages/core/src/lib/builder/index.ts
+++ b/packages/core/src/lib/builder/index.ts
@@ -1,4 +1,3 @@
-import cloneDeep from 'lodash-es/cloneDeep';
 import { UIConfig } from '../../exports';
 import { UIRoot, Element as E, StyleProps } from '../../types/ui-config/root';
 import { defaultConfig } from '../default-ui-config';
@@ -139,7 +138,7 @@ export class DyteUIBuilder {
   private config: UIConfig;
 
   constructor(config?: UIConfig) {
-    this.config = cloneDeep(config || defaultConfig);
+    this.config = config || defaultConfig;
   }
 
   /**


### PR DESCRIPTION
| Linear Issue |
| :----------: |
| fixes WEB-4109 |

### Description
There was a peculiar issue where in [ui kit add-ons](https://github.com/dyte-io/ui-kit-addons/blob/main/index.html#L91) if hand raise, if not place last, will not show the hand raise button in control bar, and fail with an error in console logs.

<img width="602" alt="image" src="https://github.com/user-attachments/assets/30de98d0-8f2c-4023-b816-95f25c4bf381">

It was happening because config was being cloned on every `register` method call of every addon.

Since all other addons work with the meeting object they have received in register method, they work as expected, even if placed anywhere in the registerAddons list.

However hand raise button gets added using config and gets its properties, as well, such as `meeting` from config . 

If config gets cloned deeply, identity of meeting object gets lost. If identity is lost, WeakMap of web-core CDN build cannot match the meeting object, with the meeting object that it has, so build throws `Cannot read from private field` error.

In the below image `Oe` is WeakMap and `de` is the cloned meeting object with a changed wrapper thus has a new identity and therefore .has() doesn't return true.

<img width="795" alt="image" src="https://github.com/user-attachments/assets/b29bcf9c-24ed-4132-8a55-940a33bc952b">

When we place handRaise at the end of the array, no one clones the config object after it so issue doesn't get reproduced.  Placing it anywhere before the end of the array causes the issue.

### Alternate approach
Fix web-core build to not use WeakMap and rather let a cloned meeting object access to its private method. 

**Why it was not picked instead?**
1. I see no point of cloning huge objects such as meeting & config.
2. i see no point of having cloneDeep method called before calling register method for each addon. Ideally if a config gets altered even without the builder, then also it should be honoured. I also don't see how cloneDeep can help us from avoiding accidental changes to config.
3. Fixing web-core build is increasing blast radius.

### Screenshots

WeakMap reference check
<img width="795" alt="image" src="https://github.com/user-attachments/assets/b29bcf9c-24ed-4132-8a55-940a33bc952b">

Addon Error
<img width="602" alt="image" src="https://github.com/user-attachments/assets/30de98d0-8f2c-4023-b816-95f25c4bf381">

