### PR TITLE
fix(dyte-participant-tile): network disconnected icon is not going away due to incorrect field

### DIFF
--- a/packages/core/src/components/dyte-participant-tile/dyte-participant-tile.tsx
+++ b/packages/core/src/components/dyte-participant-tile/dyte-participant-tile.tsx
@@ -142,7 +142,7 @@ export class DyteParticipantTile {
   }
 
   private mediaConnectionUpdateListener() {
-    const { consuming, producing } = this.meeting?.meta?.mediaState ?? {};
+    const { recv: consuming, send: producing } = this.meeting?.meta?.mediaState ?? {};
 
     if (consuming?.state !== 'connected' && !this.isSelf()) {
       this.mediaConnectionError = true;


### PR DESCRIPTION
| Linear Issue |
| :----------: |
| fixes WEB-4133 |

### Description

With some changes around media refactoring in web-core, consuming & receiving meeting.meta.mediaStates were renamed to send & recv, which were missed in ui-kit code, causing issues.

Fixing the fields.

### Screenshots

<img width="566" alt="image" src="https://github.com/user-attachments/assets/822cc833-cf25-439d-bc3d-c4196ae1f256" />

