### PR TITLE
ci(release): fixed released, using npm ci instead of install, updated utils to match web-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build package
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build package
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,9 +3322,10 @@
       }
     },
     "node_modules/@dyteinternals/utils": {
-      "version": "1.11.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dyteinternals/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-OOzk2/bpZGawVRcEHQ2778YO/Pl3oIj9DzObHxug9FjE72xpuB8vWIIQFb4lBmuOFs/bHiZFdchUraSMQeatlA==",
       "dev": true,
-      "license": "UNLICENSED",
       "dependencies": {
         "axios": "^0.25.0",
         "lodash-es": "^4.17.21"
@@ -3347,9 +3348,9 @@
       "link": true
     },
     "node_modules/@dytesdk/web-core": {
-      "version": "2.1.10-staging.4",
-      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-2.1.10-staging.4.tgz",
-      "integrity": "sha512-Vc6kSbdbZ/l+QJcZCb8zwu0p/rH0S8vnlA+Qq4knPM2mrTWZ//00BQjivOWxFzik5SZY7+Mvo2340A4l8JoUwA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-2.2.0.tgz",
+      "integrity": "sha512-q8hko1grbnvGencDGsCuVJrzeSuJf9qkGCTw5tz2PSjqxrxwvpyoh8QYNz8lRiMn+TpCRxP4v7boTX9F+kU5EQ==",
       "dev": true,
       "dependencies": {
         "@protobuf-ts/runtime": "^2.7.0",
@@ -7490,8 +7491,9 @@
     },
     "node_modules/axios": {
       "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.7"
       }
@@ -26160,7 +26162,7 @@
         "resize-observer-polyfill": "^1.5.1"
       },
       "devDependencies": {
-        "@dyteinternals/utils": "^1.7.10",
+        "@dyteinternals/utils": "^3.1.0",
         "@dytesdk/web-core": "staging",
         "@rollup/plugin-commonjs": "24.0.1",
         "@rollup/plugin-node-resolve": "15.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "tag": "latest"
   },
   "peerDepdendencies": {
-    "@dytesdk/web-core": ">=2.0.0"
+    "@dytesdk/web-core": ">=2.2.0"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.1.0",
@@ -50,7 +50,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {
-    "@dyteinternals/utils": "^1.7.10",
+    "@dyteinternals/utils": "^3.1.0",
     "@dytesdk/web-core": "staging",
     "@rollup/plugin-commonjs": "24.0.1",
     "@rollup/plugin-node-resolve": "15.0.1",


### PR DESCRIPTION
| Linear Issue |
| :----------: |
| fixes WEB-4133 |

### Description

Fixed CI/CD release workflow. It was failing because it was picking an old web-core version that wasn't compatible. Using CI to avoid all sorts of caches. 