### PR TITLE
fix(breakout-rooms): breakout room button is missing was cases where config was not re-evaluated

### DIFF
--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -6,7 +6,6 @@ import { isValidHexColor } from './color';
 import deepMerge from 'lodash-es/merge';
 import { Meeting } from '../types/dyte-client';
 import { isLiveStreamHost } from './livestream';
-import { canToggleBreakout } from './breakout-rooms';
 
 /**
  * Extend the default UI Config with your own
@@ -78,9 +77,7 @@ export const generateConfig = (
       moreElements.push('dyte-mute-all-button');
     }
 
-    if (canToggleBreakout(meeting)) {
-      moreElements.push('dyte-breakout-rooms-toggle');
-    }
+    moreElements.push('dyte-breakout-rooms-toggle');
 
     if (meeting.self?.permissions.canRecord) {
       moreElements.push('dyte-recording-toggle');


### PR DESCRIPTION
| Linear Issue |
| :----------: |
| fixes WEB-4143 |

### Description

Breakout rooms toggle was not showing up if config was not re-evaluated, even when breakout was enabled and breakout was going on.

Though the proper fix would be to ensure re-evaluation but there could always be faulty useEffects when it comes to react.

Removing the check from config because breakout room toggle button is already doing this check https://github.com/dyte-io/ui-kit/blob/main/packages/core/src/components/dyte-breakout-room-toggle/dyte-breakout-rooms-toggle.tsx#L54 and it won't anyway render itself. Having 2 source of truths could be error prone so marking breakout rooms toggle button as the source of truth.
