### PR TITLE
fix: optimize locale object handling

### DIFF
--- a/packages/core/src/lib/lang/index.ts
+++ b/packages/core/src/lib/lang/index.ts
@@ -16,7 +16,11 @@ export type DyteI18n = (key: keyof LangDict | (string & {})) => string;
  * @returns A function which handles i18n
  */
 export const useLanguage = (lang: Partial<LangDict | {}> = defaultLanguage): DyteI18n => {
-  const locale = Object.assign({}, defaultLanguage, lang);
+  let locale = defaultLanguage;
+
+  if (lang !== defaultLanguage || Object.keys(lang).length > 0) {
+    locale = Object.assign({}, defaultLanguage, lang);
+  }
 
   return (key) => {
     return locale[key] ?? key;


### PR DESCRIPTION
Too many locale objects are created when using `dyte-meeting` or any component where `useLanguage` will be called multiple times. This PR addresses that by making sure `useLanguage` returns the `defaultLanguage` object when needed and not new objects every time.