### PR TITLE
fix: use arrow function in plugin-main to avoid state issues

### DIFF
--- a/packages/core/src/components/dyte-plugin-main/dyte-plugin-main.tsx
+++ b/packages/core/src/components/dyte-plugin-main/dyte-plugin-main.tsx
@@ -44,11 +44,11 @@ export class DytePluginMain {
     this.pluginChanged(this.plugin);
   }
 
-  private onIframeRef(el: HTMLIFrameElement) {
+  private onIframeRef = (el: HTMLIFrameElement) => {
     if (el === this.iframeEl) return;
     this.iframeEl = el;
     this.plugin?.addPluginView(el, 'plugin-main');
-  }
+  };
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {


### PR DESCRIPTION
Use arrow function in plugin-main component to avoid stable state issues.