### PR TITLE
fix(dyte-controlbar-button): add focus outline and move interaction styles onto button

### DIFF
--- a/packages/core/src/components/dyte-ai-toggle/dyte-ai-toggle.css
+++ b/packages/core/src/components/dyte-ai-toggle/dyte-ai-toggle.css
@@ -1,3 +1,8 @@
 :host {
   display: block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}

--- a/packages/core/src/components/dyte-ai-toggle/dyte-ai-toggle.tsx
+++ b/packages/core/src/components/dyte-ai-toggle/dyte-ai-toggle.tsx
@@ -63,7 +63,7 @@ export class DyteAiToggle {
     const text = this.t('ai.meeting_ai');
 
     if (!(this.meeting?.self?.permissions as DytePermissionsPreset).transcriptionEnabled) {
-      return null;
+      return <Host data-hidden />;
     }
 
     return (

--- a/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.css
+++ b/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.css
@@ -3,3 +3,8 @@
 :host {
   display: block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}

--- a/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.tsx
+++ b/packages/core/src/components/dyte-camera-toggle/dyte-camera-toggle.tsx
@@ -191,7 +191,7 @@ export class DyteCameraToggle {
       this.meeting?.meta.viewType === 'AUDIO_ROOM' ||
       ['OFF_STAGE', 'REQUESTED_TO_JOIN_STAGE'].includes(this.stageStatus)
     ) {
-      return null;
+      return <Host data-hidden />;
     }
 
     const { tooltipLabel, label, icon, classList, showWarning, disable } = this.getState();

--- a/packages/core/src/components/dyte-chat-toggle/dyte-chat-toggle.css
+++ b/packages/core/src/components/dyte-chat-toggle/dyte-chat-toggle.css
@@ -4,6 +4,11 @@
   @apply relative block;
 }
 
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}
+
 .unread-count {
   @apply absolute right-3 box-border p-0.5;
   @apply select-none;

--- a/packages/core/src/components/dyte-chat-toggle/dyte-chat-toggle.css
+++ b/packages/core/src/components/dyte-chat-toggle/dyte-chat-toggle.css
@@ -22,8 +22,6 @@
 }
 
 :host([variant='horizontal']) {
-  @apply flex flex-row-reverse items-center;
-
   .unread-count {
     @apply right-4 top-auto;
   }

--- a/packages/core/src/components/dyte-chat-toggle/dyte-chat-toggle.tsx
+++ b/packages/core/src/components/dyte-chat-toggle/dyte-chat-toggle.tsx
@@ -130,7 +130,7 @@ export class DyteChatToggle {
   };
 
   render() {
-    if (!this.canViewChat) return;
+    if (!this.canViewChat) return <Host data-hidden />;
     return (
       <Host title={this.t('chat')}>
         {usePaginatedChat(this.meeting)

--- a/packages/core/src/components/dyte-controlbar-button/dyte-controlbar-button.css
+++ b/packages/core/src/components/dyte-controlbar-button/dyte-controlbar-button.css
@@ -8,11 +8,10 @@
   --icon-size: var(--dyte-controlbar-button-icon-size, theme('spacing.7'));
   --button-spacing: var(--dyte-controlbar-button-spacing, theme('spacing.1'));
 
-  @apply relative box-border inline-flex !outline-none;
-  @apply min-w-20 mx-0.5 h-full w-auto;
-  @apply select-none rounded-md transition-colors;
+  @apply relative box-border inline-flex;
+  @apply min-w-20 h-full w-auto px-0.5;
+  @apply select-none transition-colors;
   @apply text-text-1000;
-  border: theme('borderWidth.md') solid theme('colors.transparent');
 
   background-color: var(--background-color);
 }
@@ -32,7 +31,8 @@ button {
 button {
   @apply box-border inline-flex h-full w-full flex-1 flex-col;
   @apply items-center justify-center;
-  @apply cursor-pointer border-none bg-transparent text-inherit outline-none;
+  @apply cursor-pointer rounded-md border-none bg-transparent text-inherit outline-offset-[-2px];
+  border: theme('borderWidth.md') solid theme('colors.transparent');
 }
 
 .label {
@@ -50,7 +50,7 @@ button {
   @apply h-3 w-3;
 }
 
-:host(:hover) {
+:host(:hover) button {
   @apply bg-background-800;
 }
 
@@ -66,14 +66,18 @@ button {
   --button-spacing: 0px;
 }
 
-:host(.leave:hover) {
+:host(.leave:hover) button {
   @apply bg-background-1000 text-danger;
   border: theme('borderWidth.md') solid theme('colors.danger');
 }
 
-:host(.active) {
+:host(.active) button {
   @apply text-brand-400;
   border: theme('borderWidth.md') solid theme('colors.brand.400');
+}
+
+button:focus-visible {
+  outline: 2px solid theme('colors.brand.400');
 }
 
 :host(.active-livestream) {
@@ -88,9 +92,12 @@ button {
 }
 
 :host([variant='horizontal']) {
-  @apply m-0 h-12 w-full px-5 py-3;
+  @apply w-full;
 
   button {
+    /* 7px because the parent container has an 8px radius, but a 1px thick border */
+    @apply rounded-[7px];
+    @apply m-0 h-12 w-full px-5 py-3;
     @apply flex-row justify-start;
   }
 

--- a/packages/core/src/components/dyte-controlbar-button/dyte-controlbar-button.css
+++ b/packages/core/src/components/dyte-controlbar-button/dyte-controlbar-button.css
@@ -6,10 +6,9 @@
     theme('colors.background.1000')
   );
   --icon-size: var(--dyte-controlbar-button-icon-size, theme('spacing.7'));
-  --button-spacing: var(--dyte-controlbar-button-spacing, theme('spacing.1'));
 
   @apply relative box-border inline-flex;
-  @apply min-w-20 h-full w-auto px-0.5;
+  @apply min-w-20 h-full w-auto;
   @apply select-none transition-colors;
   @apply text-text-1000;
 
@@ -29,7 +28,7 @@ button {
 }
 
 button {
-  @apply box-border inline-flex h-full w-full flex-1 flex-col;
+  @apply box-border inline-flex h-full w-full flex-1 flex-col gap-1 px-1;
   @apply items-center justify-center;
   @apply cursor-pointer rounded-md border-none bg-transparent text-inherit outline-offset-[-2px];
   border: theme('borderWidth.md') solid theme('colors.transparent');
@@ -55,15 +54,8 @@ button {
 }
 
 #icon {
-  margin-bottom: var(--button-spacing);
   width: var(--icon-size);
   height: var(--icon-size);
-}
-
-/* Remove margin-bottom for `sm` buttons and in horizontal variant */
-:host([size='sm']),
-:host([variant='horizontal']) {
-  --button-spacing: 0px;
 }
 
 :host(.leave:hover) button {
@@ -85,7 +77,7 @@ button:focus-visible {
 }
 
 :host([size='sm']) {
-  @apply min-w-14 mx-0;
+  @apply min-w-14;
   .label {
     @apply hidden;
   }
@@ -97,12 +89,12 @@ button:focus-visible {
   button {
     /* 7px because the parent container has an 8px radius, but a 1px thick border */
     @apply rounded-[7px];
-    @apply m-0 h-12 w-full px-5 py-3;
-    @apply flex-row justify-start;
+    @apply h-12 w-full px-5 py-3;
+    @apply flex-row justify-start gap-3;
   }
 
   #icon {
-    @apply mr-3 w-6;
+    @apply w-6;
   }
 
   .label {
@@ -120,8 +112,6 @@ button:focus-visible {
 
 @media only screen and (max-device-height: 480px) and (orientation: landscape) {
   :host {
-    @apply mx-0;
-
     .label {
       @apply hidden;
     }

--- a/packages/core/src/components/dyte-controlbar/dyte-controlbar.css
+++ b/packages/core/src/components/dyte-controlbar/dyte-controlbar.css
@@ -1,7 +1,7 @@
 @import '../../styles/reset.css';
 
 :host {
-  @apply bg-background-1000 box-border flex items-center px-4;
+  @apply bg-background-1000 box-border flex items-center gap-0.5 px-4;
   @apply relative z-10;
 }
 

--- a/packages/core/src/components/dyte-fullscreen-toggle/dyte-fullscreen-toggle.css
+++ b/packages/core/src/components/dyte-fullscreen-toggle/dyte-fullscreen-toggle.css
@@ -3,3 +3,8 @@
 :host {
   @apply block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}

--- a/packages/core/src/components/dyte-fullscreen-toggle/dyte-fullscreen-toggle.tsx
+++ b/packages/core/src/components/dyte-fullscreen-toggle/dyte-fullscreen-toggle.tsx
@@ -83,7 +83,7 @@ export class DyteFullscreenToggle {
 
   render() {
     if (!this.isFullScreenSupported) {
-      return null;
+      return <Host data-hidden />;
     }
 
     return (

--- a/packages/core/src/components/dyte-livestream-toggle/dyte-livestream-toggle.css
+++ b/packages/core/src/components/dyte-livestream-toggle/dyte-livestream-toggle.css
@@ -3,3 +3,8 @@
 :host {
   @apply block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}

--- a/packages/core/src/components/dyte-livestream-toggle/dyte-livestream-toggle.tsx
+++ b/packages/core/src/components/dyte-livestream-toggle/dyte-livestream-toggle.tsx
@@ -138,7 +138,7 @@ export class DyteLivestreamToggle {
   };
 
   render() {
-    if (!isLiveStreamHost(this.meeting)) return;
+    if (!isLiveStreamHost(this.meeting)) return <Host data-hidden />;
     return (
       <Host>
         <dyte-controlbar-button

--- a/packages/core/src/components/dyte-mic-toggle/dyte-mic-toggle.css
+++ b/packages/core/src/components/dyte-mic-toggle/dyte-mic-toggle.css
@@ -4,6 +4,11 @@
   display: block;
 }
 
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}
+
 :host(.audioDisabled) {
   :slotted(dyte-icon) {
     @apply text-danger;

--- a/packages/core/src/components/dyte-mic-toggle/dyte-mic-toggle.tsx
+++ b/packages/core/src/components/dyte-mic-toggle/dyte-mic-toggle.tsx
@@ -191,7 +191,7 @@ export class DyteMicToggle {
       !this.canProduceAudio ||
       ['OFF_STAGE', 'REQUESTED_TO_JOIN_STAGE'].includes(this.stageStatus)
     ) {
-      return null;
+      return <Host data-hidden />;
     }
 
     const { tooltipLabel, label, icon, classList, showWarning, disable } = this.getState();

--- a/packages/core/src/components/dyte-more-toggle/dyte-more-toggle.css
+++ b/packages/core/src/components/dyte-more-toggle/dyte-more-toggle.css
@@ -6,6 +6,7 @@
 
 .more-menu {
   @apply border-background-600 border-sm bg-background-1000 absolute -right-24 bottom-16 z-50 mb-3 box-border max-h-[60vh] w-64 overflow-auto rounded-md border-solid outline-none;
+  @apply flex flex-col items-stretch;
 }
 
 :host([size='sm']) {

--- a/packages/core/src/components/dyte-participants-toggle/dyte-participants-toggle.css
+++ b/packages/core/src/components/dyte-participants-toggle/dyte-participants-toggle.css
@@ -15,8 +15,6 @@
 }
 
 :host([variant='horizontal']) {
-  @apply flex flex-row-reverse items-center;
-
   .waiting-participants-count {
     @apply right-4 top-auto;
   }

--- a/packages/core/src/components/dyte-participants-toggle/dyte-participants-toggle.css
+++ b/packages/core/src/components/dyte-participants-toggle/dyte-participants-toggle.css
@@ -4,6 +4,11 @@
   @apply relative block;
 }
 
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}
+
 .waiting-participants-count {
   @apply absolute right-3 box-border p-0.5;
   @apply select-none;

--- a/packages/core/src/components/dyte-participants-toggle/dyte-participants-toggle.tsx
+++ b/packages/core/src/components/dyte-participants-toggle/dyte-participants-toggle.tsx
@@ -163,7 +163,7 @@ export class DyteParticipantsToggle {
   };
 
   render() {
-    if (!this.canViewParticipants) return;
+    if (!this.canViewParticipants) return <Host data-hidden />;
     const text = this.t('participants');
     // const badgeCount = this.waitlistedParticipants.length + this.stageRequestedParticipants.length;
     return (

--- a/packages/core/src/components/dyte-pip-toggle/dyte-pip-toggle.css
+++ b/packages/core/src/components/dyte-pip-toggle/dyte-pip-toggle.css
@@ -3,3 +3,8 @@
 :host {
   display: block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}

--- a/packages/core/src/components/dyte-pip-toggle/dyte-pip-toggle.tsx
+++ b/packages/core/src/components/dyte-pip-toggle/dyte-pip-toggle.tsx
@@ -75,7 +75,7 @@ export class DytePipToggle {
     if (!this.pipSupported) return;
     const pipEnabled = this.meeting.participants.pip.isActive;
     return (
-      <Host tabIndex={0} role="log" aria-label={`Picture-in-Picture mode`}>
+      <Host role="log" aria-label={`Picture-in-Picture mode`}>
         <dyte-controlbar-button
           part="controlbar-button"
           size={this.size}

--- a/packages/core/src/components/dyte-pip-toggle/dyte-pip-toggle.tsx
+++ b/packages/core/src/components/dyte-pip-toggle/dyte-pip-toggle.tsx
@@ -72,7 +72,7 @@ export class DytePipToggle {
   }
 
   render() {
-    if (!this.pipSupported) return;
+    if (!this.pipSupported) return <Host data-hidden />;
     const pipEnabled = this.meeting.participants.pip.isActive;
     return (
       <Host role="log" aria-label={`Picture-in-Picture mode`}>

--- a/packages/core/src/components/dyte-plugins-toggle/dyte-plugins-toggle.css
+++ b/packages/core/src/components/dyte-plugins-toggle/dyte-plugins-toggle.css
@@ -3,3 +3,8 @@
 :host {
   @apply block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}

--- a/packages/core/src/components/dyte-plugins-toggle/dyte-plugins-toggle.tsx
+++ b/packages/core/src/components/dyte-plugins-toggle/dyte-plugins-toggle.tsx
@@ -96,7 +96,7 @@ export class DytePluginsToggle {
   };
 
   render() {
-    if (!this.canViewPlugins) return;
+    if (!this.canViewPlugins) return <Host data-hidden />;
 
     const text = this.t('plugins');
 

--- a/packages/core/src/components/dyte-polls-toggle/dyte-polls-toggle.css
+++ b/packages/core/src/components/dyte-polls-toggle/dyte-polls-toggle.css
@@ -3,6 +3,12 @@
 :host {
   @apply relative block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}
+
 .unread-count {
   @apply absolute right-3 box-border p-0.5;
   @apply select-none;

--- a/packages/core/src/components/dyte-polls-toggle/dyte-polls-toggle.css
+++ b/packages/core/src/components/dyte-polls-toggle/dyte-polls-toggle.css
@@ -14,8 +14,6 @@
 }
 
 :host([variant='horizontal']) {
-  @apply flex flex-row-reverse items-center;
-
   .unread-count {
     @apply right-4 top-auto;
   }

--- a/packages/core/src/components/dyte-polls-toggle/dyte-polls-toggle.tsx
+++ b/packages/core/src/components/dyte-polls-toggle/dyte-polls-toggle.tsx
@@ -110,7 +110,7 @@ export class DytePollsToggle {
   };
 
   render() {
-    if (!this.canViewPolls) return;
+    if (!this.canViewPolls) return <Host data-hidden />;
     const text = this.t('polls');
     // TODO(callmetarush): Just showing polls for all V2 users irrespective of themes
     // untill we get ui theme for V2.

--- a/packages/core/src/components/dyte-screen-share-toggle/dyte-screen-share-toggle.css
+++ b/packages/core/src/components/dyte-screen-share-toggle/dyte-screen-share-toggle.css
@@ -3,3 +3,8 @@
 :host {
   display: block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}

--- a/packages/core/src/components/dyte-screen-share-toggle/dyte-screen-share-toggle.tsx
+++ b/packages/core/src/components/dyte-screen-share-toggle/dyte-screen-share-toggle.tsx
@@ -306,7 +306,7 @@ export class DyteScreenShareToggle {
       !this.canScreenShare ||
       ['OFF_STAGE', 'REQUESTED_TO_JOIN_STAGE'].includes(this.stageStatus)
     ) {
-      return null;
+      return <Host data-hidden />;
     }
 
     return (

--- a/packages/core/src/components/dyte-stage-toggle/dyte-stage-toggle.css
+++ b/packages/core/src/components/dyte-stage-toggle/dyte-stage-toggle.css
@@ -3,3 +3,8 @@
 :host {
   display: block;
 }
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}

--- a/packages/core/src/components/dyte-stage-toggle/dyte-stage-toggle.tsx
+++ b/packages/core/src/components/dyte-stage-toggle/dyte-stage-toggle.tsx
@@ -140,7 +140,7 @@ export class DyteStageToggle {
   }
 
   render() {
-    if (!canRequestToJoinStage(this.meeting)) return;
+    if (!canRequestToJoinStage(this.meeting)) return <Host data-hidden />;
     return (
       <Host title={this.state.label}>
         <dyte-tooltip

--- a/packages/core/src/lib/default-ui-config.ts
+++ b/packages/core/src/lib/default-ui-config.ts
@@ -76,10 +76,12 @@ export const defaultConfig: UIConfig = {
     'div#controlbar-left': {
       display: 'flex',
       alignItems: 'center',
+      gap: 'var(--dyte-space-1, 4px)',
     },
     'div#controlbar-center': {
       display: 'flex',
       alignItems: 'center',
+      gap: 'var(--dyte-space-1, 4px)',
       position: 'relative',
       overflow: 'visible',
       justifyContent: 'center',
@@ -88,11 +90,13 @@ export const defaultConfig: UIConfig = {
       display: 'flex',
       flex: '1',
       alignItems: 'center',
+      gap: 'var(--dyte-space-1, 4px)',
       justifyContent: 'center',
     },
     'div#controlbar-right': {
       display: 'flex',
       alignItems: 'center',
+      gap: 'var(--dyte-space-1, 4px)',
       justifyContent: 'flex-end',
     },
     'dyte-settings': {

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -296,6 +296,7 @@ export const generateConfig = (
       'div#controlbar-left': {
         display: 'flex',
         alignItems: 'center',
+        gap: 'var(--dyte-space-1, 4px)',
       },
       'div#controlbar-center': {
         display: 'flex',
@@ -303,6 +304,7 @@ export const generateConfig = (
         position: 'relative',
         overflow: 'visible',
         justifyContent: 'center',
+        gap: 'var(--dyte-space-1, 4px)',
       },
       'div#controlbar-mobile': {
         display: 'flex',
@@ -310,11 +312,13 @@ export const generateConfig = (
         alignItems: 'center',
         justifyContent: 'center',
         zIndex: '10000',
+        gap: 'var(--dyte-space-1, 4px)',
       },
       'div#controlbar-right': {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'flex-end',
+        gap: 'var(--dyte-space-1, 4px)',
       },
       'dyte-settings': {
         width: '720px',


### PR DESCRIPTION
### Description
Keyboard users should have some visual feedback about what element is currently focused, so that's been added. Additionally, in order for the outline to have the same border-radius, the interaction styles such as background and border styles have been moved onto the button element itself.

### Screenshots

New outline when `:focus-visible` is applied
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/692bf777-f81a-4f08-935b-ce2a4c4a0a68" />

Previous styles are still preserved when hovering:
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/6e0ea46a-617b-4224-a9d1-bdcd4193310e" />
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/2416892a-de2b-46b4-bb3f-4c4b5902b318" />

This also applies to the buttons in the sub-menu:
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/f150f511-3cc7-4c35-902b-e234e484abb5" />

