### PR TITLE
feat(dyte-emoji-picker): optionally focus emoji picker search when opened

### DIFF
--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -1273,14 +1273,14 @@ export declare interface DyteDraftAttachmentView extends Components.DyteDraftAtt
 
 
 @ProxyCmp({
-  inputs: ['iconPack', 't']
+  inputs: ['focusWhenOpened', 'iconPack', 't']
 })
 @Component({
   selector: 'dyte-emoji-picker',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['iconPack', 't'],
+  inputs: ['focusWhenOpened', 'iconPack', 't'],
 })
 export class DyteEmojiPicker {
   protected el: HTMLDyteEmojiPickerElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1359,6 +1359,10 @@ export namespace Components {
      */
     interface DyteEmojiPicker {
         /**
+          * Controls whether or not to focus on mount
+         */
+        "focusWhenOpened": boolean;
+        /**
           * Icon pack
          */
         "iconPack": IconPack;
@@ -8033,6 +8037,10 @@ declare namespace LocalJSX {
      * A very simple emoji picker component.
      */
     interface DyteEmojiPicker {
+        /**
+          * Controls whether or not to focus on mount
+         */
+        "focusWhenOpened"?: boolean;
         /**
           * Icon pack
          */

--- a/packages/core/src/components/dyte-emoji-picker/dyte-emoji-picker.css
+++ b/packages/core/src/components/dyte-emoji-picker/dyte-emoji-picker.css
@@ -17,7 +17,7 @@
 }
 
 #emoji-grid {
-  @apply mt-2 box-border flex flex-row flex-wrap;
+  @apply mt-2 box-border flex flex-row flex-wrap content-start;
   @apply overflow-x-hidden overflow-y-scroll;
   @apply h-full;
   grid-auto-rows: minmax(min-content, max-content);

--- a/packages/core/src/components/dyte-emoji-picker/dyte-emoji-picker.tsx
+++ b/packages/core/src/components/dyte-emoji-picker/dyte-emoji-picker.tsx
@@ -24,6 +24,10 @@ export class DyteEmojiPicker {
   @Prop()
   t: DyteI18n = useLanguage();
 
+  /** Controls whether or not to focus on mount */
+  @Prop()
+  focusWhenOpened = true;
+
   /** Close event */
   @Event() pickerClose: EventEmitter<void>;
 
@@ -36,12 +40,21 @@ export class DyteEmojiPicker {
    */
   @Event({ eventName: 'dyteEmojiClicked' }) emojiClicked: EventEmitter<string>;
 
+  /** Input element ref */
+  private inputElement!: HTMLInputElement;
+
   componentWillLoad() {
     // Don't use async here as it will block the render
     fetchEmojis().then((e) => {
       this.emojiList = e;
-      this.handleInputChange({ value: '' });
+      this.handleInputChange(this.inputElement);
     });
+  }
+
+  componentDidLoad() {
+    if (this.focusWhenOpened) {
+      this.inputElement.focus();
+    }
   }
 
   private handleInputChange(target) {
@@ -101,6 +114,7 @@ export class DyteEmojiPicker {
             value={this.filterVal}
             onInput={(event) => this.handleInputChange(event.target)}
             placeholder={this.t('search')}
+            ref={(el) => (this.inputElement = el)}
           ></input>
           {this.mapEmojiList()}
         </div>

--- a/packages/core/src/utils/assets.ts
+++ b/packages/core/src/utils/assets.ts
@@ -2,11 +2,16 @@ import { EmojiMetaData } from '../types/props';
 
 const EMOJI_ASSET_URL = 'https://cdn.dyte.in/assets/emojis-data.json';
 
+let cachedEmojis: any;
+
 /**
  * fetches the latest emoji list from CDN
  * @returns list of emojis
  */
 export const fetchEmojis = async (): Promise<Record<string, EmojiMetaData>> => {
-  const emojis = await fetch(EMOJI_ASSET_URL);
-  return emojis.json();
+  if (!cachedEmojis) {
+    const emojis = await fetch(EMOJI_ASSET_URL);
+    cachedEmojis = emojis.json();
+  }
+  return cachedEmojis;
 };

--- a/packages/vue-library/lib/components.ts
+++ b/packages/vue-library/lib/components.ts
@@ -585,6 +585,7 @@ export const DyteDraftAttachmentView = /*@__PURE__*/ defineContainer<JSX.DyteDra
 export const DyteEmojiPicker = /*@__PURE__*/ defineContainer<JSX.DyteEmojiPicker>('dyte-emoji-picker', undefined, [
   'iconPack',
   't',
+  'focusWhenOpened',
   'pickerClose',
   'dyteEmojiClicked'
 ], [


### PR DESCRIPTION
### Description

- added focusWhenOpened prop to control this behavior, defaults to true
- Fixed flex layout issue that would only appear when search results showed a small enough (less than a full page) matches for the query.
- Fixed an issue where if search input was populated before emojis load the search query would be erased
- Keeps emoji json data in memory so it is only fetched once. Also, it looks like the cdn is setting `cache-control: no-cache` in the response!

### Screenshots

Before:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/e49c0cb0-be7b-4980-90cb-b82b63268070" />

After:
<img width="410" alt="image" src="https://github.com/user-attachments/assets/868a2d60-1a8e-471f-912d-a1a30335d1bf" />

