### PR TITLE
feat(dyte-dialog): use dialog element for better focus management

### DIFF
--- a/packages/core/src/components/dyte-confirmation-modal/dyte-confirmation-modal.css
+++ b/packages/core/src/components/dyte-confirmation-modal/dyte-confirmation-modal.css
@@ -21,7 +21,7 @@
   @apply text-text-md;
 }
 
-.leave-message p {
+.leave-modal p {
   @apply my-3;
 }
 
@@ -32,10 +32,6 @@
 .leave-meeting dyte-button {
   @apply text-text-1000;
   @apply flex-1;
-}
-
-.end-meeting {
-  @apply mt-2;
 }
 
 .br-secondary-btn {

--- a/packages/core/src/components/dyte-confirmation-modal/dyte-confirmation-modal.tsx
+++ b/packages/core/src/components/dyte-confirmation-modal/dyte-confirmation-modal.tsx
@@ -76,7 +76,7 @@ export class DyteConfirmationModal {
               {state.header ? this.t(state.header) : this.t('cta.confirmation')}
             </h2>
           </div>
-          <p class="message">{state.content ? this.t(state.content) : ''}</p>
+          {state.content && <p class="message">{this.t(state.content)}</p>}
           <div class="content">
             <div class="leave-meeting">
               <dyte-button

--- a/packages/core/src/components/dyte-dialog/dyte-dialog.css
+++ b/packages/core/src/components/dyte-dialog/dyte-dialog.css
@@ -1,29 +1,18 @@
 @import '../../styles/reset.css';
 
-/**
- * NOTE(vaibhavshn):
- * The code for visibility and display below are set after careful consideration
- * as the .hydrated class overrides the visibility properly.
- * Thus the background overlay would be visible, even in closed state
- */
-
 :host {
-  @apply fixed inset-0 box-border p-4;
-  @apply flex-col items-center justify-center;
-  @apply bg-background-600/50 text-text-1000;
-  /* Hide dialog by default */
-  @apply invisible hidden;
-
-  @apply break-words;
   word-wrap: break-word;
-
-  z-index: 60;
-
-  backdrop-filter: blur(12px) saturate(180%);
+  @apply break-words;
 }
 
 #dialog {
-  @apply relative max-h-full max-w-full;
+  @apply relative max-h-full max-w-full p-0;
+  @apply text-text-1000 border-none bg-transparent;
+}
+
+#dialog::backdrop {
+  @apply bg-background-600/50;
+  backdrop-filter: blur(12px) saturate(180%);
 }
 
 #dismiss-btn {
@@ -32,14 +21,4 @@
 
 ::slotted(*) {
   @apply max-h-full max-w-full;
-}
-
-/* Show only when open="true" */
-:host([open]) {
-  @apply visible flex;
-}
-
-/* Hide dialog by default */
-:host([open='false']) {
-  @apply invisible hidden;
 }

--- a/packages/core/src/components/dyte-dialog/dyte-dialog.tsx
+++ b/packages/core/src/components/dyte-dialog/dyte-dialog.tsx
@@ -73,6 +73,15 @@ export class DyteDialog {
     }
   };
 
+  private dialogEl: HTMLDialogElement;
+
+  componentDidRender() {
+    if (this.open && !this.dialogEl.open) {
+      // we need to call showModal() to get the ::backdrop
+      this.dialogEl.showModal();
+    }
+  }
+
   render() {
     if (!this.open) {
       return null;
@@ -80,7 +89,23 @@ export class DyteDialog {
 
     return (
       <Host>
-        <div id="dialog" part="container" role="dialog" aria-modal="true">
+        <dialog
+          ref={(el) => (this.dialogEl = el)}
+          id="dialog"
+          part="container"
+          onClose={this.close}
+          onClick={(e) => {
+            // clicked outside the children of dialog
+            if (!this.disableEscapeKey && e.target === this.dialogEl) {
+              this.close();
+            }
+          }}
+          onKeyDown={(e) => {
+            if (this.disableEscapeKey && e.key === 'Escape') {
+              e.preventDefault();
+            }
+          }}
+        >
           <slot />
           {!this.hideCloseButton && (
             <dyte-button
@@ -96,7 +121,7 @@ export class DyteDialog {
               <dyte-icon icon={this.iconPack.dismiss} />
             </dyte-button>
           )}
-        </div>
+        </dialog>
       </Host>
     );
   }


### PR DESCRIPTION
### Description

This PR updates the `dyte-dialog` component to use the `dialog` element, which buys us a couple big things:

- Automatic focus management
  - The first focusable element in the dialog is focused when the dialog opens
  - Focus is trapped within the dialog while it is open
  - Focus is restored to whatever element was focused prior to the dialog opening
- Takes advantage of the [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer) so we don't need to worry about possible z-index issues, esp within the context of these components being used on someone else's website!