### PR TITLE
feat(dyte-notifications): pause notification timeouts while focused/hovered

### DIFF
--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -2307,14 +2307,14 @@ export declare interface DyteNetworkIndicator extends Components.DyteNetworkIndi
 
 
 @ProxyCmp({
-  inputs: ['iconPack', 'notification', 'size', 't']
+  inputs: ['iconPack', 'notification', 'paused', 'size', 't']
 })
 @Component({
   selector: 'dyte-notification',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['iconPack', 'notification', 'size', 't'],
+  inputs: ['iconPack', 'notification', 'paused', 'size', 't'],
 })
 export class DyteNotification {
   protected el: HTMLDyteNotificationElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -2369,6 +2369,10 @@ export namespace Components {
          */
         "notification": Notification;
         /**
+          * Stops timeout when true
+         */
+        "paused": boolean;
+        /**
           * Size
          */
         "size": Size;
@@ -9149,6 +9153,10 @@ declare namespace LocalJSX {
           * Dismiss event
          */
         "onDyteNotificationDismiss"?: (event: DyteNotificationCustomEvent<string>) => void;
+        /**
+          * Stops timeout when true
+         */
+        "paused"?: boolean;
         /**
           * Size
          */

--- a/packages/core/src/components/dyte-leave-meeting/dyte-leave-meeting.tsx
+++ b/packages/core/src/components/dyte-leave-meeting/dyte-leave-meeting.tsx
@@ -139,20 +139,16 @@ export class DyteLeaveMeeting {
                 {this.t('breakout_rooms.leave_confirmation.main_room_btn')}
               </dyte-button>
             )}
-            <dyte-button
-              variant={this.canEndMeeting ? 'secondary' : 'danger'}
-              title={this.t('leave')}
-              onClick={this.handleLeave}
-              class={{
-                'secondary-btn': this.canEndMeeting,
-                'secondary-danger-btn': this.canEndMeeting,
-              }}
-            >
+            <dyte-button variant="danger" title={this.t('leave')} onClick={this.handleLeave}>
               {this.t('leave')}
             </dyte-button>
 
             {this.canEndMeeting && (
-              <dyte-button variant="danger" onClick={this.handleEndMeeting}>
+              <dyte-button
+                variant="danger"
+                class="secondary-btn secondary-danger-btn"
+                onClick={this.handleEndMeeting}
+              >
                 {this.t('end.all')}
               </dyte-button>
             )}

--- a/packages/core/src/components/dyte-notification/dyte-notification.css
+++ b/packages/core/src/components/dyte-notification/dyte-notification.css
@@ -9,7 +9,7 @@
 }
 
 .ctr {
-  @apply min-w-40 box-border inline-flex h-full items-center px-3;
+  @apply min-w-40 box-border inline-flex h-full items-center pl-3 pr-2;
   @apply bg-background-600 select-none rounded-md;
   @apply shadow-background-1000 shadow-md;
   @apply pointer-events-auto;
@@ -42,22 +42,23 @@ dyte-icon.icon {
   @apply text-text-900;
 }
 
-dyte-icon.dismiss {
-  @apply ml-auto h-5 w-5;
-  @apply text-text-600 hover:text-text-1000 rounded-md hover:cursor-pointer;
+button.dismiss {
+  @apply flex h-6 w-6 items-center justify-center border-none p-0;
+  @apply text-text-600 outline-text-1000 rounded-sm bg-transparent outline-1;
+  @apply hover:text-text-1000 hover:cursor-pointer focus-visible:outline;
   @apply transition-colors;
 }
 
+.dismiss dyte-icon {
+  @apply h-5 w-5;
+}
+
 dyte-button {
-  @apply ml-4 mr-2 rounded-sm;
+  @apply rounded-sm;
 }
 
 .right {
-  @apply ml-auto flex items-center;
-
-  & > * {
-    @apply ml-2 first:ml-0;
-  }
+  @apply ml-auto flex items-center gap-2;
 }
 
 :host(.exit) {

--- a/packages/core/src/components/dyte-notification/dyte-notification.tsx
+++ b/packages/core/src/components/dyte-notification/dyte-notification.tsx
@@ -20,6 +20,9 @@ export class DyteNotification {
   /** Message */
   @Prop() notification!: Notification;
 
+  /** Stops timeout when true */
+  @Prop() paused: boolean;
+
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
 
@@ -42,10 +45,21 @@ export class DyteNotification {
     this.notificationChanged(this.notification);
   }
 
+  private timeout: number;
+
+  @Watch('paused')
+  pausedChanged(paused: boolean) {
+    if (paused) {
+      clearTimeout(this.timeout);
+    } else {
+      this.notificationChanged(this.notification);
+    }
+  }
+
   @Watch('notification')
   notificationChanged(notification: Notification) {
-    if (notification != null && typeof notification.duration === 'number') {
-      setTimeout(() => {
+    if (notification != null && typeof notification.duration === 'number' && !this.paused) {
+      this.timeout = window.setTimeout(() => {
         this.dismiss.emit(notification.id);
       }, notification.duration);
     }
@@ -85,12 +99,9 @@ export class DyteNotification {
                 {this.notification.button.text}
               </dyte-button>
             )}
-            <dyte-icon
-              aria-label={this.t('dismiss')}
-              class="dismiss"
-              icon={this.iconPack.dismiss}
-              onClick={() => this.dismiss.emit(this.notification.id)}
-            />
+            <button onClick={() => this.dismiss.emit(this.notification.id)} class="dismiss">
+              <dyte-icon aria-label={this.t('dismiss')} icon={this.iconPack.dismiss} />
+            </button>
           </div>
         </div>
       </Host>

--- a/packages/core/src/components/dyte-notifications/dyte-notifications.tsx
+++ b/packages/core/src/components/dyte-notifications/dyte-notifications.tsx
@@ -653,20 +653,31 @@ export class DyteNotifications {
     );
   }
 
+  @State()
+  paused = false;
+
   render() {
     return (
       <Host>
-        {this.notifications.map((notification) => (
-          <dyte-notification
-            size={this.size}
-            key={notification.id}
-            data-id={notification.id}
-            notification={notification}
-            onDyteNotificationDismiss={(e: CustomEvent<string>) => this.handleDismiss(e)}
-            iconPack={this.iconPack}
-            t={this.t}
-          />
-        ))}
+        <div
+          onMouseEnter={() => (this.paused = true)}
+          onFocusin={() => (this.paused = true)}
+          onMouseLeave={() => (this.paused = false)}
+          onFocusout={() => (this.paused = false)}
+        >
+          {this.notifications.map((notification) => (
+            <dyte-notification
+              size={this.size}
+              key={notification.id}
+              data-id={notification.id}
+              notification={notification}
+              onDyteNotificationDismiss={(e: CustomEvent<string>) => this.handleDismiss(e)}
+              iconPack={this.iconPack}
+              paused={this.paused}
+              t={this.t}
+            />
+          ))}
+        </div>
       </Host>
     );
   }

--- a/packages/vue-library/lib/components.ts
+++ b/packages/vue-library/lib/components.ts
@@ -1014,6 +1014,7 @@ export const DyteNetworkIndicator = /*@__PURE__*/ defineContainer<JSX.DyteNetwor
 
 export const DyteNotification = /*@__PURE__*/ defineContainer<JSX.DyteNotification>('dyte-notification', undefined, [
   'notification',
+  'paused',
   'size',
   'iconPack',
   't',


### PR DESCRIPTION
### Description
- After playing around for a little bit with the webinar functionality I noticed the notifications can disappear from under you if you're not fast enough while trying to click. To alleviate this, we can stop the timeout when the user is about to interact with the notification (either via focus or mouseover) and restart it when they either move the mouse out or focus something other than a notification.
- Also made the dismiss icon into a button!
