### PR TITLE
fix(overflow menu buttons): fix vertical positioning of badges in overflow menu

### DIFF
--- a/packages/core/src/components/dyte-chat-toggle/dyte-chat-toggle.css
+++ b/packages/core/src/components/dyte-chat-toggle/dyte-chat-toggle.css
@@ -28,6 +28,6 @@
 
 :host([variant='horizontal']) {
   .unread-count {
-    @apply right-4 top-auto;
+    @apply right-4 top-1/2 translate-y-[-50%];
   }
 }

--- a/packages/core/src/components/dyte-participants-toggle/dyte-participants-toggle.css
+++ b/packages/core/src/components/dyte-participants-toggle/dyte-participants-toggle.css
@@ -21,6 +21,6 @@
 
 :host([variant='horizontal']) {
   .waiting-participants-count {
-    @apply right-4 top-auto;
+    @apply right-4 top-1/2 translate-y-[-50%];
   }
 }

--- a/packages/core/src/components/dyte-polls-toggle/dyte-polls-toggle.css
+++ b/packages/core/src/components/dyte-polls-toggle/dyte-polls-toggle.css
@@ -21,6 +21,6 @@
 
 :host([variant='horizontal']) {
   .unread-count {
-    @apply right-4 top-auto;
+    @apply right-4 top-1/2 translate-y-[-50%];
   }
 }


### PR DESCRIPTION
### Description

Fixes an issue with vertical alignment of badges that was introduced by https://github.com/dyte-io/ui-kit/pull/101

### Screenshots

Before:
![image](https://github.com/user-attachments/assets/7cceec87-dccd-4261-8a26-c1b6323fc73e)

After:
![image](https://github.com/user-attachments/assets/89ef64e6-810b-4455-812a-3e833572c640)

