### PR TITLE
fix(breakout-rooms): breakout rooms were not starting the first time

### DIFF
--- a/packages/core/src/components/dyte-meeting/dyte-meeting.tsx
+++ b/packages/core/src/components/dyte-meeting/dyte-meeting.tsx
@@ -223,14 +223,14 @@ export class DyteMeeting {
     this.updateStates(e.detail);
   }
 
-  private handleChangingMeeting(destinationMeetingId: string) {
+  private handleChangingMeeting = (destinationMeetingId: string) => {
     this.updateStates({
       activeBreakoutRoomsManager: {
         ...uiState.states.activeBreakoutRoomsManager,
         destinationMeetingId,
       },
     });
-  }
+  };
 
   private handleResize() {
     this.size = getSize(this.host.clientWidth);

--- a/packages/core/src/components/dyte-ui-provider/dyte-ui-provider.tsx
+++ b/packages/core/src/components/dyte-ui-provider/dyte-ui-provider.tsx
@@ -215,14 +215,14 @@ export class DyteUiProvider {
     }
   };
 
-  private handleChangingMeeting(destinationMeetingId: string) {
+  private handleChangingMeeting = (destinationMeetingId: string) => {
     this.updateStates({
       activeBreakoutRoomsManager: {
         ...uiState.states.activeBreakoutRoomsManager,
         destinationMeetingId,
       },
     });
-  }
+  };
 
   render() {
     return <Host>{this.noRenderUntilMeeting && !this.meeting ? null : <slot />}</Host>;


### PR DESCRIPTION
### Description

Users were not able to switch to Breakout rooms due to an internal error in UI Kit (updateStates is not a function). It used to work on a retry because the listener is attached on the meeting using once so it doesn't interfere the next time.

Same was happening for cases such as Join another breakout room, Move to main room.

### Fix
Fixed `this` binding to ensure correct updateStates function gets picked.
