### PR TITLE
chore(release): breakout room joining & creation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [3.0.2-staging.1](https://github.com/dyte-io/ui-kit/compare/@dyte-in/ui-kit-v3.0.1...@dyte-in/ui-kit-v3.0.2-staging.1) (2025-04-30)
+
+
+### Bug Fixes
+
+* **breakout-rooms:** breakout rooms were not starting the first time ([810abbe](https://github.com/dyte-io/ui-kit/commit/810abbe577b512911ccad0f24d5f286733be8535))
+* **breakout-rooms:** updated ui-kit provider as well for state sync ([e648312](https://github.com/dyte-io/ui-kit/commit/e648312e8e2dabce8a178351e39c10f76980ab87))
+
 ## [3.0.1](https://github.com/dyte-io/ui-kit/compare/@dyte-in/ui-kit-v3.0.0...@dyte-in/ui-kit-v3.0.1) (2025-04-14)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35884,7 +35884,7 @@
     },
     "packages/core": {
       "name": "@dytesdk/ui-kit",
-      "version": "3.0.1",
+      "version": "3.0.2-staging.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -36175,7 +36175,7 @@
     },
     "packages/react-library": {
       "name": "@dytesdk/react-ui-kit",
-      "version": "3.0.1",
+      "version": "3.0.2-staging.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@dytesdk/ui-kit": "*"
@@ -36230,7 +36230,7 @@
     },
     "packages/vue-library": {
       "name": "@dytesdk/vue-ui-kit",
-      "version": "3.0.1",
+      "version": "3.0.2-staging.1",
       "dependencies": {
         "@dytesdk/ui-kit": "*",
         "@stencil/vue-output-target": "^0.9.6"

--- a/packages/angular-library/projects/components/package.json
+++ b/packages/angular-library/projects/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dytesdk/angular-ui-kit",
-  "version": "3.0.1",
+  "version": "3.0.2-staging.1",
   "description": "Dyte's UI Kit to support easy UI development for Angular Projects",
   "peerDependencies": {
     "@angular/common": ">=12",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dytesdk/ui-kit",
-  "version": "3.0.1",
+  "version": "3.0.2-staging.1",
   "description": "Dyte's UI kit to support easy UI development over the core web library.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/core/src/components/dyte-meeting/dyte-meeting.tsx
+++ b/packages/core/src/components/dyte-meeting/dyte-meeting.tsx
@@ -223,14 +223,14 @@ export class DyteMeeting {
     this.updateStates(e.detail);
   }
 
-  private handleChangingMeeting(destinationMeetingId: string) {
+  private handleChangingMeeting = (destinationMeetingId: string) => {
     this.updateStates({
       activeBreakoutRoomsManager: {
         ...uiState.states.activeBreakoutRoomsManager,
         destinationMeetingId,
       },
     });
-  }
+  };
 
   private handleResize() {
     this.size = getSize(this.host.clientWidth);

--- a/packages/core/src/components/dyte-ui-provider/dyte-ui-provider.tsx
+++ b/packages/core/src/components/dyte-ui-provider/dyte-ui-provider.tsx
@@ -215,14 +215,14 @@ export class DyteUiProvider {
     }
   };
 
-  private handleChangingMeeting(destinationMeetingId: string) {
+  private handleChangingMeeting = (destinationMeetingId: string) => {
     this.updateStates({
       activeBreakoutRoomsManager: {
         ...uiState.states.activeBreakoutRoomsManager,
         destinationMeetingId,
       },
     });
-  }
+  };
 
   render() {
     return <Host>{this.noRenderUntilMeeting && !this.meeting ? null : <slot />}</Host>;

--- a/packages/react-library/package.json
+++ b/packages/react-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dytesdk/react-ui-kit",
-  "version": "3.0.1",
+  "version": "3.0.2-staging.1",
   "description": "Dyte's UI Kit to support easy UI development for React.",
   "repository": {
     "type": "git",

--- a/packages/vue-library/package.json
+++ b/packages/vue-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dytesdk/vue-ui-kit",
-  "version": "3.0.1",
+  "version": "3.0.2-staging.1",
   "description": "Dyte's UI Kit to support easy UI development for Vue.",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
### Description
Users were not able to switch to Breakout rooms due to an internal error in UI Kit (updateStates is not a function). It used to work on a retry because the listener is attached on the meeting using once so it doesn't interfere the next time.

Same was happening for cases such as Join another breakout room, Move to main room.

### Fix
Fixed this binding to ensure correct updateStates function gets picked.