### PR TITLE
fix: update stage requests based on events from participants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2750,9 +2750,9 @@
       "link": true
     },
     "node_modules/@dytesdk/web-core": {
-      "version": "2.5.0-staging.26",
-      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-2.5.0-staging.26.tgz",
-      "integrity": "sha512-dnfOeixR+V3RMLuFbCPc4JC3Jv6LeBPwg/l7uAHxYsz0b6X5g+lNPTc2S/gzpM3sXkWlWyKE93/+rrFf08rnkQ==",
+      "version": "2.5.0-staging.91",
+      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-2.5.0-staging.91.tgz",
+      "integrity": "sha512-lP9P7pVekLfn9flrC6tEN9q/gTkxM1U+i5jzgLHyIzTO7VrRB+bcsXTWgAq/Q75HHbTivrLLCS2L1yvZztMNQQ==",
       "dev": true,
       "dependencies": {
         "@protobuf-ts/runtime": "^2.7.0",
@@ -35895,7 +35895,7 @@
       },
       "devDependencies": {
         "@dyteinternals/utils": "^3.1.0",
-        "@dytesdk/web-core": "^2.5.0-staging.26",
+        "@dytesdk/web-core": "^2.5.0-staging.91",
         "@rollup/plugin-commonjs": "^28.0.2",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@dyteinternals/utils": "^3.1.0",
-    "@dytesdk/web-core": "^2.5.0-staging.26",
+    "@dytesdk/web-core": "^2.5.0-staging.91",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",

--- a/packages/core/src/components/dyte-participants-stage-queue/dyte-participants-stage-queue.tsx
+++ b/packages/core/src/components/dyte-participants-stage-queue/dyte-participants-stage-queue.tsx
@@ -51,6 +51,9 @@ export class DyteParticipantsStaged {
     if (meeting == null) return;
 
     this.updateRequestList();
+    meeting.participants.joined.on('stageStatusUpdate', (e) => {
+      this.updateStageRequestedParticipants();
+    });
     meeting.stage?.on('stageAccessRequestUpdate', this.updateRequestList);
   }
 
@@ -63,23 +66,19 @@ export class DyteParticipantsStaged {
   private acceptStageRequest = async (p: Peer) => {
     const { userId } = p;
     await this.meeting.stage.grantAccess([userId]);
-    this.updateStageRequestedParticipants();
   };
 
   private rejectStageRequest = async (p: Peer) => {
     const { userId } = p;
     await this.meeting.stage.denyAccess([userId]);
-    this.updateStageRequestedParticipants();
   };
 
   private acceptAllStageRequest = async () => {
     await this.meeting.stage.grantAccess(this.stageRequestedParticipants.map((p) => p.userId));
-    this.updateStageRequestedParticipants();
   };
 
   private denyAllStageRequest = async () => {
     await this.meeting.stage?.denyAccess(this.stageRequestedParticipants.map((p) => p.userId));
-    this.updateStageRequestedParticipants();
   };
 
   private shouldShowStageRequests = () => {


### PR DESCRIPTION
### Description

Earlier on we would wait for button click and immediately check the participant list for stage status update, instead check for event coming from participants notifying us of a stage status update and then update the list
